### PR TITLE
fix refresh token TTL

### DIFF
--- a/src/main/java/sample/redis/RedisOAuth2AuthorizationService.java
+++ b/src/main/java/sample/redis/RedisOAuth2AuthorizationService.java
@@ -100,7 +100,7 @@ public class RedisOAuth2AuthorizationService implements OAuth2AuthorizationServi
         Duration accessTokenTtl = registeredClient.getTokenSettings().getAccessTokenTimeToLive();
         Duration refreshTokenTtl = registeredClient.getTokenSettings().getRefreshTokenTimeToLive();
         Duration stateTtl = codeTtl;
-        Duration max = authorization.getRefreshToken() != null ?
+        Duration max = authorization.getRefreshToken() == null ?
             accessTokenTtl : Collections.max(Arrays.asList(accessTokenTtl, refreshTokenTtl));
         Duration authorizationTtl = max;
         Duration correlationsTtl = max;


### PR DESCRIPTION
Only when there's no refresh token use the access token's TTL, otherwise use the max TTL of access token and refresh token.